### PR TITLE
ActiveRecordのScope機能で、在庫がある製品だけをクエリするscope追加した

### DIFF
--- a/store/app/models/product.rb
+++ b/store/app/models/product.rb
@@ -6,4 +6,6 @@ class Product < ApplicationRecord
   has_rich_text :description
   validates :name, presence: true
   validates :inventory_count, numericality: { greater_than_or_equal_to: 0 }
+
+  scope :in_stock, -> { where("inventory_count > 0") }
 end

--- a/store/spec/factories/products.rb
+++ b/store/spec/factories/products.rb
@@ -1,7 +1,15 @@
 FactoryBot.define do
   factory :product do
     name { Faker::Commerce.product_name }
-    inventory_count { 15 }
+    inventory_count { Faker::Number.within(range: 1..9999) }
+  end
+
+  trait :out_of_stock do
+    inventory_count { 0 }
+  end
+
+  trait :in_stock do
+    inventory_count { Faker::Number.within(range: 1..9999) }
   end
 
   trait :with_1_subscriber do

--- a/store/spec/models/product_spec.rb
+++ b/store/spec/models/product_spec.rb
@@ -42,7 +42,7 @@ RSpec.describe Product, type: :model do # Productモデルのテストコード�
       it "空配列を返すこと" do
         FactoryBot.create_list(:product, Faker::Number.within(range: 1..100), :out_of_stock)
 
-        expect(Product.in_stock).to eq([])
+        expect(Product.in_stock).to match_array([])
       end
     end
   end

--- a/store/spec/models/product_spec.rb
+++ b/store/spec/models/product_spec.rb
@@ -30,9 +30,9 @@ RSpec.describe Product, type: :model do # Productモデルのテストコード�
   describe ".in_stock" do
     context "在庫がある商品があるとき" do
       it "在庫がある商品のみを返すこと" do
-        in_stock_product_1 = FactoryBot.create(:product, inventory_count: 1)
-        in_stock_product_2 = FactoryBot.create(:product, inventory_count: 2)
-        out_of_stock_product = FactoryBot.create(:product, inventory_count: 0)
+        in_stock_product_1 = FactoryBot.create(:product, :in_stock)
+        in_stock_product_2 = FactoryBot.create(:product, :in_stock)
+        out_of_stock_product = FactoryBot.create(:product, :out_of_stock)
 
         expect(Product.in_stock).to contain_exactly(in_stock_product_1, in_stock_product_2)
       end
@@ -40,7 +40,7 @@ RSpec.describe Product, type: :model do # Productモデルのテストコード�
 
     context "どの商品も在庫なしの場合" do
       it "空配列を返すこと" do
-        FactoryBot.create(:product, inventory_count: 0)
+        FactoryBot.create(:product, :out_of_stock)
 
         expect(Product.in_stock).to eq([])
       end

--- a/store/spec/models/product_spec.rb
+++ b/store/spec/models/product_spec.rb
@@ -26,4 +26,24 @@ RSpec.describe Product, type: :model do # Productモデルのテストコード�
       product.update(inventory_count: 99)
     end
   end
+
+  describe ".in_stock" do
+    context "在庫がある商品があるとき" do
+      it "在庫がある商品のみを返すこと" do
+        in_stock_product_1 = FactoryBot.create(:product, inventory_count: 1)
+        in_stock_product_2 = FactoryBot.create(:product, inventory_count: 2)
+        out_of_stock_product = FactoryBot.create(:product, inventory_count: 0)
+
+        expect(Product.in_stock).to contain_exactly(in_stock_product_1, in_stock_product_2)
+      end
+    end
+
+    context "どの商品も在庫なしの場合" do
+      it "空配列を返すこと" do
+        FactoryBot.create(:product, inventory_count: 0)
+
+        expect(Product.in_stock).to eq([])
+      end
+    end
+  end
 end

--- a/store/spec/models/product_spec.rb
+++ b/store/spec/models/product_spec.rb
@@ -30,17 +30,17 @@ RSpec.describe Product, type: :model do # Productモデルのテストコード�
   describe ".in_stock" do
     context "在庫がある商品があるとき" do
       it "在庫がある商品のみを返すこと" do
-        in_stock_product_1 = FactoryBot.create(:product, :in_stock)
-        in_stock_product_2 = FactoryBot.create(:product, :in_stock)
-        out_of_stock_product = FactoryBot.create(:product, :out_of_stock)
+        # 作成するProductレコードの個数は1以上のランダムな個数に設定しているが、固定値でもいいかもしれない
+        in_stock_products = FactoryBot.create_list(:product, Faker::Number.within(range: 1..100), :in_stock)
+        FactoryBot.create_list(:product, Faker::Number.within(range: 1..100), :out_of_stock)
 
-        expect(Product.in_stock).to contain_exactly(in_stock_product_1, in_stock_product_2)
+        expect(Product.in_stock).to match_array(in_stock_products)
       end
     end
 
     context "どの商品も在庫なしの場合" do
       it "空配列を返すこと" do
-        FactoryBot.create(:product, :out_of_stock)
+        FactoryBot.create_list(:product, Faker::Number.within(range: 1..100), :out_of_stock)
 
         expect(Product.in_stock).to eq([])
       end


### PR DESCRIPTION
# 概要

- [ActiveRecordのScope機能](https://guides.rubyonrails.org/active_record_querying.html#scopes)の勉強のため、在庫がある製品だけをクエリする`.in_stock`scope追加してみた
- 追加したscopeはRSpecでテストするようにした
- FactoryBotでテストに使うProductレコードを作るとき、inventory数をランダム化するようにした
- FactoryBotでテストに使うProductレコードを作るとき、作る個数も1～100のランダムな個数を作るようにした