### PR TITLE
M1 macでDevContainerを動かしている時、deltaのインストールがアーキテクチャー違いで動かない問題に対応した

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -9,10 +9,12 @@ RUN su vscode -c "/usr/local/rvm/bin/rvm fix-permissions"
 ENV RAILS_DEVELOPMENT_HOSTS=".githubpreview.dev,.preview.app.github.dev,.app.github.dev"
 
 # Delta - A syntax-highlighting pager for git, diff, grep, and blame output をインストール
-RUN DELTA_VERSION=$(curl -sL "https://api.github.com/repos/dandavison/delta/releases/latest" | jq -r '.name') \
-    && curl -o /tmp/git-delta_latest_amd64.deb -L https://github.com/dandavison/delta/releases/download/${DELTA_VERSION}/git-delta_${DELTA_VERSION}_amd64.deb \
-    && apt-get install -y /tmp/git-delta_latest_amd64.deb \
-    && rm -f /tmp/git-delta_latest_amd64.deb
+RUN ARCH=$(uname -m) \
+    && DELTA_ARCH=$(if [ "$ARCH" = "arm64" ] || [ "$ARCH" = "aarch64" ]; then echo "arm64"; else echo "amd64"; fi) \
+    && DELTA_VERSION=$(curl -sL "https://api.github.com/repos/dandavison/delta/releases/latest" | jq -r '.name') \
+    && curl -o /tmp/git-delta_latest_${DELTA_ARCH}.deb -L https://github.com/dandavison/delta/releases/download/${DELTA_VERSION}/git-delta_${DELTA_VERSION}_${DELTA_ARCH}.deb \
+    && apt-get install -y /tmp/git-delta_latest_${DELTA_ARCH}.deb \
+    && rm -f /tmp/git-delta_latest_${DELTA_ARCH}.deb
 
 # [Optional] Uncomment this section to install additional OS packages.
 # RUN apt-get update && export DEBIAN_FRONTEND=noninteractive \


### PR DESCRIPTION
# 概要

- M1 macでDevContainerを動かしている時、deltaはarm64のものをインストールしないといけないのでそれに対応した
- Dockerfileの書き換えはRoo Codeに書いてもらった